### PR TITLE
Adding subformats to metaData generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ Format of *img.json*
 
 ```
 {
-	"img_name": {
-		"description": "img_description"
-	}
+	"description": "img_description"
 }
 
 ```
@@ -104,6 +102,18 @@ Above formats can also be accessed interactively using mode=1
 ```
 openmemes --generate=1 --mode=1 --format=1
 ```
+### Ratings
+Meme_generation also supports ratings now , and these ratings can be used subjectively for setting trending memes and creating recommendations.
+```
+--generate=1 --mode=0 --format=3 --image1=path --image2 =path --text1=text --text2=text --rating=value_from_0_to_5
+```
+
+### Description
+At the time of meme generation a description can be assigned to the meme for lookup and classification based use cases.
+```
+--generate=1 --mode=0 --format=3 --image1=path --image2 =path --text1=text --text2=text --description=description_text
+```
+
 ## Testing
 The project can be tested for errors using the command
 ```

--- a/data/got_memes/images/meme-got01.json
+++ b/data/got_memes/images/meme-got01.json
@@ -1,6 +1,6 @@
 {
     "mode": "0",
-    "format": "1",
+    "format": "1.1",
     "description": "NewMeme",
     "rating": 0
 }

--- a/index/timestamp.json
+++ b/index/timestamp.json
@@ -1,1 +1,1 @@
-{"last-updated": "Thu Mar 21 18:45:43 2019"}
+{"last-updated": "Wed Mar 27 16:31:21 2019"}

--- a/meme_generator.py
+++ b/meme_generator.py
@@ -121,20 +121,23 @@ def start(args):
 
         if args.format == '1':
             if args.text1 and args.text2 and args.image1:
+                metaData['format'] += '.1'
                 preprocessImages(args.image1)
                 formatObj = Format1(image_path=args.image1,top_text=args.text1,bottom_text=args.text2)
                 use(formatObj, metaData)
 
             elif args.text1 and args.image1:
+                metaData['format'] += '.2'
                 preprocessImages(args.image1)
                 formatObj = Format1(image_path=args.image1,top_text=args.text1,bottom_text=None)
                 use(formatObj, metaData)
 
             elif args.text2 and args.image1:
+                metaData['format'] += '.3'
                 preprocessImages(args.image1)
                 formatObj = Format1(image_path=args.image1,top_text=None,bottom_text=args.text2)
                 use(formatObj, metaData)
-		
+
             else:
                 print('Missing arguments')
 
@@ -178,6 +181,7 @@ def start(args):
             img = input('Enter the image path: ')
             print(format1type1, format1type2, format1type3)
             user_res = input('Select one of the formats (default : 1): ')
+            metaData['format'] += user_res
             if user_res == '1':
                 preprocessImages(img)
                 top_text = input('Input the top line here: ')
@@ -210,6 +214,7 @@ def start(args):
             preprocessImages(img2)
             print(format3type1, format3type2, format3type3, format3type4)
             type = input('Select the layout of meme (default : 1): ')
+            metaData['format'] += type
 
             top_text = list()
             bottom_text = list()
@@ -220,7 +225,7 @@ def start(args):
                 top_text.append(text1)
                 bottom_text.append(text2)
                 formatObj = Format3(image1_path=img1,image2_path=img2,top_text=top_text,bottom_text=bottom_text)
-		
+
             elif type == '2':
                 text1 = input('Input the top spreading text: ')
                 text2 = input('Input the line for first image: ')
@@ -229,8 +234,8 @@ def start(args):
                 bottom_text.append(text2)
                 bottom_text.append(text3)
                 formatObj = Format3(image1_path=img1,image2_path=img2,top_text=top_text,bottom_text=bottom_text)
-            
-	    elif type == '3':
+
+            elif type == '3':
                 text1 = input('Input the line for first image: ')
                 text2 = input('Input the line for second image: ')
                 text3 = input('Input the bottom spreading line: ')
@@ -238,7 +243,7 @@ def start(args):
                 top_text.append(text2)
                 bottom_text.append(text3)
                 formatObj = Format3(image1_path=img1,image2_path=img2,top_text=top_text,bottom_text=bottom_text)
-		
+
             elif type == '4':
                 text1 = input('Input the top line for first image: ')
                 text2 = input('Input the top line for second image: ')
@@ -270,6 +275,7 @@ def start(args):
             img = 'meme_img.jpg'
             print(format1type1, format1type2, format1type3)
             user_res = input('Select one of the formats (default : 1): ')
+            metaData['format'] += user_res
 
             if user_res == '1' or user_res == '':
                 preprocessImages(img)
@@ -322,6 +328,7 @@ def start(args):
 
             print(format3type1, format3type2, format3type3, format3type4)
             type = input('Select the layout of meme (default : 1): ')
+            metaData['format'] += type
 
             top_text = list()
             bottom_text = list()
@@ -332,7 +339,7 @@ def start(args):
                 top_text.append(text1)
                 bottom_text.append(text2)
                 formatObj = Format3(image1_path=img1,image2_path=img2,top_text=top_text,bottom_text=bottom_text)
-		
+
             elif type == '2':
                 text1 = input('Input the top spreading text: ')
                 text2 = input('Input the line for first image: ')


### PR DESCRIPTION
Now the metaData is generated with the format including the information about the subformats.

## MetaData format
![Screenshot (12)](https://user-images.githubusercontent.com/23142350/55071471-b43dee80-50ae-11e9-93cd-c8beac8cbe48.png)

## Test Report

![Screenshot (13)](https://user-images.githubusercontent.com/23142350/55071514-dc2d5200-50ae-11e9-9e3f-2f00bcb79352.png)
